### PR TITLE
Correcting usage of an undefined variable

### DIFF
--- a/MY_Model.php
+++ b/MY_Model.php
@@ -709,7 +709,7 @@ class MY_Model extends CI_Model {
     {
         $data = $this->trigger('before_update', $data);
 
-        if ($skip_validation === FALSE)
+        if ($this->skip_validation === FALSE)
         {
             $data = $this->validate($data);
             if ( ! $data)


### PR DESCRIPTION
In method update_all, i found usage of an undefined variable while verifying if validation should be skipped of not. This PR is a proposition for correction